### PR TITLE
Adds maxAgeDays parameter to functions that decode cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ CreateSignedValue signs and timestamps a string so it cannot be forged.
 #### func  DecodeSignedValue
 
 ```go
-func DecodeSignedValue(secret, name, signedValue string) (string, error)
+func DecodeSignedValue(secret, name, signedValue string, maxAgeDays int) (string, error)
 ```
 DecodeSignedValue returns the given signed cookie if it validates, or error.
 
 #### func  GetSecureCookie
 
 ```go
-func GetSecureCookie(r *http.Response, secret, name string) (*http.Cookie, error)
+func GetSecureCookie(r *http.Response, secret, name string, maxAgeDays int) (*http.Cookie, error)
 ```
 GetSecureCookie returns the named cookie provided in the response or ErrNoCookie
 if not found, or error if secure cookie value cannot be decoded. Secret should
@@ -34,7 +34,7 @@ be a long, random sequence of bytes
 #### func  MustDecodeSignedValue
 
 ```go
-func MustDecodeSignedValue(secret, name, signedValue string) string
+func MustDecodeSignedValue(secret, name, signedValue string, maxAgeDays int) string
 ```
 
 #### func  SetSecureCookie

--- a/securecookie.go
+++ b/securecookie.go
@@ -9,139 +9,139 @@
 package securecookie
 
 import (
-	"bytes"
-	"crypto/hmac"
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/hex"
-	"fmt"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
+    "bytes"
+    "crypto/hmac"
+    "crypto/sha1"
+    "encoding/base64"
+    "encoding/hex"
+    "fmt"
+    "net/http"
+    "strconv"
+    "strings"
+    "time"
 )
 
 // WithCookie is usually a http.Request or http.Response.
 type WithCookie interface {
-	Cookies() []*http.Cookie
+    Cookies() []*http.Cookie
 }
 
 func cookieIsExpired(cookieTime time.Time, maxAgeDays int) bool {
-	return cookieTime.Before(time.Now().AddDate(0, 0, -maxAgeDays))
+    return cookieTime.Before(time.Now().AddDate(0, 0, -maxAgeDays))
 }
 
 func cookieIsFromFuture(cookieTime time.Time, maxAgeDays int) bool {
-	return cookieTime.After(time.Now().AddDate(0, 0, maxAgeDays))
+    return cookieTime.After(time.Now().AddDate(0, 0, maxAgeDays))
 }
 
 func cookieIsTampered(timestamp []byte) bool {
-	return bytes.HasPrefix(timestamp, []byte("0"))
+    return bytes.HasPrefix(timestamp, []byte("0"))
 }
 
 func checkTimestamp(bTimestamp []byte, maxAgeDays int) error {
-	var timestamp int64
+    var timestamp int64
 
-	if t, err := strconv.ParseInt(string(bTimestamp), 0, 64); err != nil {
-		return fmt.Errorf("Invalid timestamp: %v, got error: %s",
-			bTimestamp, err)
-	} else {
-		timestamp = t
-	}
+    if t, err := strconv.ParseInt(string(bTimestamp), 0, 64); err != nil {
+        return fmt.Errorf("Invalid timestamp: %v, got error: %s",
+            bTimestamp, err)
+    } else {
+        timestamp = t
+    }
 
-	cookieTime := time.Unix(timestamp, 0)
+    cookieTime := time.Unix(timestamp, 0)
 
-	if cookieIsExpired(cookieTime, maxAgeDays) {
-		return fmt.Errorf("Expired Cookie")
-	}
+    if cookieIsExpired(cookieTime, maxAgeDays) {
+        return fmt.Errorf("Expired Cookie")
+    }
 
-	if cookieIsFromFuture(cookieTime, maxAgeDays) {
-		return fmt.Errorf("Cookie timestamp is in the future," +
-			"possible tampering")
-	}
+    if cookieIsFromFuture(cookieTime, maxAgeDays) {
+        return fmt.Errorf("Cookie timestamp is in the future," +
+            "possible tampering")
+    }
 
-	if cookieIsTampered(bTimestamp) {
-		return fmt.Errorf("Tampered cookie")
-	}
+    if cookieIsTampered(bTimestamp) {
+        return fmt.Errorf("Tampered cookie")
+    }
 
-	return nil
+    return nil
 }
 
 // DecodeSignedValue returns the given signed cookie if it validates, or error.
 func DecodeSignedValue(secret, name, signedValue string, maxAgeDays int) (string, error) {
-	var decodedValue string
+    var decodedValue string
 
-	if signedValue == "" {
-		return "", fmt.Errorf("Signed value is empty")
-	}
+    if signedValue == "" {
+        return "", fmt.Errorf("Signed value is empty")
+    }
 
-	parts := bytes.Split([]byte(signedValue), []byte("|"))
+    parts := bytes.Split([]byte(signedValue), []byte("|"))
 
-	if len(parts) != 3 {
-		return "", fmt.Errorf("Incomplete signed value")
-	}
+    if len(parts) != 3 {
+        return "", fmt.Errorf("Incomplete signed value")
+    }
 
-	value := parts[0]
-	timestamp := parts[1]
-	signature := parts[2]
+    value := parts[0]
+    timestamp := parts[1]
+    signature := parts[2]
 
-	newSignature := createSignature(secret, []byte(name), value, timestamp)
+    newSignature := createSignature(secret, []byte(name), value, timestamp)
 
-	if !bytes.Equal(signature, newSignature) {
-		return "", fmt.Errorf("Invalid signature")
-	}
+    if !bytes.Equal(signature, newSignature) {
+        return "", fmt.Errorf("Invalid signature")
+    }
 
-	if err := checkTimestamp(timestamp, maxAgeDays); err != nil {
-		return "", err
-	}
+    if err := checkTimestamp(timestamp, maxAgeDays); err != nil {
+        return "", err
+    }
 
-	if data, err := base64.URLEncoding.DecodeString(string(value)); err == nil {
-		decodedValue = string(data)
-	}
+    if data, err := base64.URLEncoding.DecodeString(string(value)); err == nil {
+        decodedValue = string(data)
+    }
 
-	return decodedValue, nil
+    return decodedValue, nil
 }
 
 func MustDecodeSignedValue(secret, name, signedValue string, maxAgeDays int) string {
-	v, err := DecodeSignedValue(secret, name, signedValue, maxAgeDays)
+    v, err := DecodeSignedValue(secret, name, signedValue, maxAgeDays)
 
-	if err != nil {
-		panic(err)
-	}
+    if err != nil {
+        panic(err)
+    }
 
-	return v
+    return v
 }
 
 func createSignature(secret string, parts ...[]byte) []byte {
-	h := hmac.New(sha1.New, []byte(secret))
+    h := hmac.New(sha1.New, []byte(secret))
 
-	for _, x := range parts {
-		h.Write(x)
-	}
+    for _, x := range parts {
+        h.Write(x)
+    }
 
-	hexDigest := make([]byte, 64)
-	hex.Encode(hexDigest, h.Sum(nil))
+    hexDigest := make([]byte, 64)
+    hex.Encode(hexDigest, h.Sum(nil))
 
-	return hexDigest[:bytes.Index(hexDigest, []byte("\000"))]
+    return hexDigest[:bytes.Index(hexDigest, []byte("\000"))]
 }
 
 // CreateSignedValue signs and timestamps a string so it cannot be forged.
 func CreateSignedValue(secret, name, value string, createdAt time.Time) string {
-	ts := fmt.Sprint(createdAt.Unix())
+    ts := fmt.Sprint(createdAt.Unix())
 
-	b64Value := base64.URLEncoding.EncodeToString([]byte(value))
+    b64Value := base64.URLEncoding.EncodeToString([]byte(value))
 
-	signature := createSignature(secret,
-		[]byte(name),
-		[]byte(b64Value),
-		[]byte(ts))
+    signature := createSignature(secret,
+        []byte(name),
+        []byte(b64Value),
+        []byte(ts))
 
-	signedValue := strings.Join([]string{b64Value, ts, fmt.Sprintf("%s", signature)}, "|")
+    signedValue := strings.Join([]string{b64Value, ts, fmt.Sprintf("%s", signature)}, "|")
 
-	return signedValue
+    return signedValue
 }
 
 func SignCookie(c *http.Cookie, secret string) {
-	c.Value = CreateSignedValue(secret, c.Name, c.Value, time.Now())
+    c.Value = CreateSignedValue(secret, c.Name, c.Value, time.Now())
 }
 
 // SetSecureCookie signs and timestamps a cookie so it cannot be forged.
@@ -150,9 +150,9 @@ func SignCookie(c *http.Cookie, secret string) {
 // Secure cookies may contain arbitrary byte values, not just unicode
 // strings (unlike regular cookies)
 func SetSecureCookie(w http.ResponseWriter, secret string, c *http.Cookie) {
-	SignCookie(c, secret)
+    SignCookie(c, secret)
 
-	http.SetCookie(w, c)
+    http.SetCookie(w, c)
 }
 
 // GetSecureCookie returns the named cookie provided in the response or ErrNoCookie if not found,
@@ -161,24 +161,24 @@ func SetSecureCookie(w http.ResponseWriter, secret string, c *http.Cookie) {
 // with http.Get client response;
 // secret should be a long, random sequence of bytes
 func GetSecureCookie(r WithCookie, secret, name string, maxAgeDays int) (*http.Cookie, error) {
-	var c *http.Cookie
+    var c *http.Cookie
 
-	for _, x := range r.Cookies() {
-		if x.Name == name {
-			c = x
-			break
-		}
-	}
+    for _, x := range r.Cookies() {
+        if x.Name == name {
+            c = x
+            break
+        }
+    }
 
-	if c == nil {
-		return nil, http.ErrNoCookie
-	}
+    if c == nil {
+        return nil, http.ErrNoCookie
+    }
 
-	if v, err := DecodeSignedValue(secret, c.Name, c.Value, maxAgeDays); err != nil {
-		return nil, err
-	} else {
-		c.Value = v
-	}
+    if v, err := DecodeSignedValue(secret, c.Name, c.Value, maxAgeDays); err != nil {
+        return nil, err
+    } else {
+        c.Value = v
+    }
 
-	return c, nil
+    return c, nil
 }

--- a/securecookie.go
+++ b/securecookie.go
@@ -9,16 +9,16 @@
 package securecookie
 
 import (
-    "bytes"
-    "crypto/hmac"
-    "crypto/sha1"
-    "encoding/base64"
-    "encoding/hex"
     "fmt"
-    "net/http"
+    "bytes"
+    "time"
+    "crypto/sha1"
+    "crypto/hmac"
+    "encoding/hex"
+    "encoding/base64"
     "strconv"
     "strings"
-    "time"
+    "net/http"
 )
 
 // WithCookie is usually a http.Request or http.Response.
@@ -43,7 +43,7 @@ func checkTimestamp(bTimestamp []byte, maxAgeDays int) error {
 
     if t, err := strconv.ParseInt(string(bTimestamp), 0, 64); err != nil {
         return fmt.Errorf("Invalid timestamp: %v, got error: %s",
-            bTimestamp, err)
+                          bTimestamp, err)
     } else {
         timestamp = t
     }
@@ -56,7 +56,7 @@ func checkTimestamp(bTimestamp []byte, maxAgeDays int) error {
 
     if cookieIsFromFuture(cookieTime, maxAgeDays) {
         return fmt.Errorf("Cookie timestamp is in the future," +
-            "possible tampering")
+                          "possible tampering")
     }
 
     if cookieIsTampered(bTimestamp) {
@@ -74,7 +74,7 @@ func DecodeSignedValue(secret, name, signedValue string, maxAgeDays int) (string
         return "", fmt.Errorf("Signed value is empty")
     }
 
-    parts := bytes.Split([]byte(signedValue), []byte("|"))
+    parts := bytes.Split([]byte(signedValue),[]byte("|"))
 
     if len(parts) != 3 {
         return "", fmt.Errorf("Incomplete signed value")
@@ -131,9 +131,9 @@ func CreateSignedValue(secret, name, value string, createdAt time.Time) string {
     b64Value := base64.URLEncoding.EncodeToString([]byte(value))
 
     signature := createSignature(secret,
-        []byte(name),
-        []byte(b64Value),
-        []byte(ts))
+                                 []byte(name),
+                                 []byte(b64Value),
+                                 []byte(ts))
 
     signedValue := strings.Join([]string{b64Value, ts, fmt.Sprintf("%s", signature)}, "|")
 

--- a/securecookie.go
+++ b/securecookie.go
@@ -160,7 +160,7 @@ func SetSecureCookie(w http.ResponseWriter, secret string, c *http.Cookie) {
 // r is usually a http.Request if you're in an handler or http.Response if you're dealing
 // with http.Get client response;
 // secret should be a long, random sequence of bytes
-func GetSecureCookie(r WithCookie, secret, name string) (*http.Cookie, error) {
+func GetSecureCookie(r WithCookie, secret, name string, expireAfterDays int) (*http.Cookie, error) {
 	var c *http.Cookie
 
 	for _, x := range r.Cookies() {
@@ -174,7 +174,7 @@ func GetSecureCookie(r WithCookie, secret, name string) (*http.Cookie, error) {
 		return nil, http.ErrNoCookie
 	}
 
-	if v, err := DecodeSignedValue(secret, c.Name, c.Value); err != nil {
+	if v, err := DecodeSignedValue(secret, c.Name, c.Value, expireAfterDays); err != nil {
 		return nil, err
 	} else {
 		c.Value = v

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -55,7 +55,7 @@ func TestDecodeSignedValue(t *testing.T) {
     }
 
     decode := func(name, signedValue string) string {
-        return MustDecodeSignedValue(secret, name, signedValue)
+        return MustDecodeSignedValue(secret, name, signedValue, 31)
     }
 
     xs := []struct {
@@ -104,7 +104,7 @@ func TestSecureCookie(t *testing.T) {
     t.Logf("Response Header: %v", resp.Header)
     t.Logf("Response Cookies: %v", resp.Cookies())
 
-    if c, err := GetSecureCookie(resp, secret, "foo"); err != nil {
+    if c, err := GetSecureCookie(resp, secret, "foo", 31); err != nil {
         t.Errorf("%v", err)
     } else {
         if c.Value != "bar" {
@@ -187,7 +187,7 @@ func TestCookieTampering(t *testing.T) {
 
     tamperedValue := fmt.Sprintf("1234|5678%v|%v", timestamp, sig)
 
-    if _, err := DecodeSignedValue(secret, "foo", tamperedValue); err == nil {
+    if _, err := DecodeSignedValue(secret, "foo", tamperedValue, 31); err == nil {
         t.Errorf("Tampered cookie should be rejected!")
     }
 }


### PR DESCRIPTION
Our cookies are valid for more days than the hardcoded value of 31 days. I think the `maxAgeDays` parameter should be part of their interface, or else these methods should not validate the age of the cookie.

Please, let me know if you are concerned with breaking changes and would rather create alternative methods.